### PR TITLE
Fix missing bin directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ $(SOURCES):
 build: main.ihx
 		@echo "Building $(OUTFILE)..."
 		@$(HEXBIN) main.ihx
+		mkdir -p bin
 		@mv main.bin bin/${OUTFILE}
 		@echo "Done."
 


### PR DESCRIPTION
This should fix missing `bin` directory creation on `Makefile` #1